### PR TITLE
Fix bug in iPickBounded; don't introduce a disjunction when translating <=

### DIFF
--- a/src/Data/Integer/SAT.hs
+++ b/src/Data/Integer/SAT.hs
@@ -179,8 +179,8 @@ prop (e1 :< e2)   = do t1 <- expr e1
 
 prop (e1 :<= e2)  = do t1 <- expr e1
                        t2 <- expr e2
-                       let t = t1 |-| t2
-                       solveIs0 t `orElse` solveIsNeg t
+                       let t = t1 |-| t2 |-| tConst 1
+                       solveIsNeg t
 
 prop (e1 :> e2)   = prop (e2 :<  e1)
 prop (e1 :>= e2)  = prop (e2 :<= e1)


### PR DESCRIPTION
This patch fixes the bug I reported on the issue tracker. The calculations in `iPickBounded` were a bit off. I haven't included the QuickCheck property I used to find the bug, since I didn't want to introduce an extra dependency on QuickCheck, but it's there in the issue tracker if you want to add it.

I also included a patch which reduces <= to < instead of introducing a disjunction.
