### PR TITLE
Needs GHC >= 7.2 due to usage of Trustworthy

### DIFF
--- a/presburger.cabal
+++ b/presburger.cabal
@@ -13,7 +13,7 @@ Build-type:     Simple
 Cabal-version:  >= 1.8
 
 library
-  Build-Depends:  base < 10, containers, pretty
+  Build-Depends:  base >= 4.4 && < 10, containers, pretty
   hs-source-dirs: src
   Exposed-modules:
     Data.Integer.SAT


### PR DESCRIPTION
```
src/Data/Integer/SAT.hs:1:14: Unsupported extension: Trustworthy
```

I've revised existing versions so a new release isn't necessary.