### PR TITLE
Workaround for GHC 8.4 (hides Semigroup.<>)

### DIFF
--- a/src/Data/Integer/SAT.hs
+++ b/src/Data/Integer/SAT.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Trustworthy, PatternGuards, BangPatterns #-}
+{-# LANGUAGE BangPatterns, PatternGuards, Trustworthy #-}
 {-|
 This module implements a decision procedure for quantifier-free linear
 arithmetic.  The algorithm is based on the following paper:
@@ -43,12 +43,13 @@ module Data.Integer.SAT
 
 import Debug.Trace
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
-import           Data.List(partition)
-import           Data.Maybe(maybeToList,fromMaybe,mapMaybe)
-import           Control.Applicative(Applicative(..), Alternative(..), (<$>))
-import           Control.Monad(liftM,ap,MonadPlus(..),guard)
+import           Control.Applicative (Alternative (..), Applicative (..), (<$>))
+import           Control.Monad       (MonadPlus (..), ap, guard, liftM)
+import           Data.List           (partition)
+import           Data.Map            (Map)
+import qualified Data.Map            as Map
+import           Data.Maybe          (fromMaybe, mapMaybe, maybeToList)
+import           Prelude             hiding ((<>))
 import           Text.PrettyPrint
 
 infixr 2 :||
@@ -85,9 +86,9 @@ assert p (State rws) = State $ fmap snd $ m =<< rws
 checkSat :: PropSet -> Maybe [(Int,Integer)]
 checkSat (State m) = go m
   where
-  go None            = mzero
-  go (One rw)        = return [ (x,v) | (UserName x, v) <- iModel (inerts rw) ]
-  go (Choice m1 m2)  = mplus (go m1) (go m2)
+  go None           = mzero
+  go (One rw)       = return [ (x,v) | (UserName x, v) <- iModel (inerts rw) ]
+  go (Choice m1 m2) = mplus (go m1) (go m2)
 
 allInerts :: PropSet -> [Inerts]
 allInerts (State m) = map inerts (toList m)
@@ -432,7 +433,7 @@ slnNextValWith f (TopVar x v lb ub is) =
      return $ TopVar x v1 lb ub is
 
 slnNextVar :: Solutions -> Maybe Solutions
-slnNextVar Done = Nothing
+slnNextVar Done                = Nothing
 slnNextVar (TopVar x v _ _ is) = Just $ FixedVar x v $ startIter $ iLet x v is
 slnNextVar (FixedVar x v i)    = FixedVar x v `fmap` slnNextVar i
 
@@ -716,9 +717,9 @@ instance Alternative Answer where
 
 instance MonadPlus Answer where
   mzero                = None
-  mplus None x         = x
+  mplus None x = x
   -- mplus (Choice x y) z = mplus x (mplus y z)
-  mplus x y            = Choice x y
+  mplus x y    = Choice x y
 
 instance Functor Answer where
   fmap _ None           = None
@@ -881,14 +882,14 @@ instance Show Term where
 ppTerm :: Term -> Doc
 ppTerm (T k m) =
   case Map.toList m of
-    [] -> integer k
-    xs | k /= 0 -> hsep (integer k : map ppProd xs)
-    x : xs      -> hsep (ppFst x   : map ppProd xs)
+    []     -> integer k
+    xs     | k /= 0 -> hsep (integer k : map ppProd xs)
+    x : xs -> hsep (ppFst x   : map ppProd xs)
 
   where
-  ppFst (x,1)   = ppName x
-  ppFst (x,-1)  = text "-" <> ppName x
-  ppFst (x,n)   = ppMul n x
+  ppFst (x,1)  = ppName x
+  ppFst (x,-1) = text "-" <> ppName x
+  ppFst (x,n)  = ppMul n x
 
   ppProd (x,1)  = text "+" <+> ppName x
   ppProd (x,-1) = text "-" <+> ppName x


### PR DESCRIPTION
As of GHC-8.4, `Semigroup` class becomes a superclass of `Monoid` and `Prelude` exposes `(<>)`.
This pull request explicitly hides `(<>)` from `Prelude`, which will be redundant and just results in warning in older GHCs.
