### PR TITLE
Cleanups. Make compile with GHC-7.2..GHC-8.10

### DIFF
--- a/presburger.cabal
+++ b/presburger.cabal
@@ -10,15 +10,20 @@ Synopsis:       A decision procedure for quantifier-free linear arithmetic.
 Description:    The decision procedure is based on the algorithm used in
                 CVC4, which is itself based on the Omega test.
 Build-type:     Simple
-Cabal-version:  >= 1.8
+Cabal-version:  >= 1.10
 
 library
+  Default-Language: Haskell2010
   Build-Depends:  base < 10, containers, pretty
   hs-source-dirs: src
   Exposed-modules:
     Data.Integer.SAT
 
   GHC-options:    -O2 -Wall
+  Other-Extensions: Trustworthy
+
+  if !impl(ghc >=8.0)
+    Build-Depends: fail ==4.9.0.0
 
 source-repository head
   type: git

--- a/src/Data/Integer/SAT.hs
+++ b/src/Data/Integer/SAT.hs
@@ -52,8 +52,15 @@ import qualified Data.Map            as Map
 import qualified Data.Map.Strict     as MapStrict
 #endif
 import           Data.Maybe          (fromMaybe, mapMaybe, maybeToList)
-import           Prelude             hiding ((<>))
 import           Text.PrettyPrint
+
+#if MIN_VERSION_base(4,9,0)
+import           Prelude hiding ((<>))
+#else
+import           Prelude
+#endif
+
+import qualified Control.Monad.Fail as Fail
 
 infixr 2 :||
 infixr 3 :&&
@@ -713,7 +720,11 @@ instance Monad Answer where
   One a >>= k        = k a
   Choice m1 m2 >>= k = mplus (m1 >>= k) (m2 >>= k)
 
-instance MonadFail Answer where
+#if !(MIN_VERSION_base(4,13,0))
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail Answer where
   fail _             = None
 
 instance Alternative Answer where


### PR DESCRIPTION
The used approaches are best practicies.
- `fail` package provides compat definition of `MonadFail` type-class
- Hackage requires at least `cabal-version: >=1.10` now.
  - Thus added `default-language`
  - But also `other-extensions: Trustworthy`, which acts as lower
    bound for supported GHCs (GHC-7.0 doesn't have Safe Haskell)