### PR TITLE
Export exposed types

### DIFF
--- a/src/Data/Integer/SAT.hs
+++ b/src/Data/Integer/SAT.hs
@@ -16,6 +16,7 @@ module Data.Integer.SAT
   , Prop(..)
   , Expr(..)
   , BoundType(..)
+  , Solutions
   , getExprBound
   , getExprRange
   , Name
@@ -30,6 +31,7 @@ module Data.Integer.SAT
 
 
   -- * Debug
+  , Inerts
   , dotPropSet
   , sizePropSet
   , allInerts
@@ -38,6 +40,7 @@ module Data.Integer.SAT
   -- * For QuickCheck
   , iPickBounded
   , Bound(..)
+  , Term
   , tConst
   ) where
 


### PR DESCRIPTION
Export all the types that appear in type signatures for exported bindings and constructors.